### PR TITLE
Fix(events): Correctly calculate next monthly occurrence

### DIFF
--- a/client/src/lib/event-logic.test.ts
+++ b/client/src/lib/event-logic.test.ts
@@ -50,4 +50,14 @@ describe('calculateNextOccurrence', () => {
     const nextOccurrence = calculateNextOccurrence(event);
     expect(nextOccurrence).toEqual(new Date('2024-01-15T18:00:00Z'));
   });
+
+  it('should handle monthly recurrence for months with different day counts', () => {
+    const event: CalendarEvent = {
+      title: 'Monthly review',
+      startDate: new Date('2024-01-31T10:00:00Z'),
+      recurring: 'monthly',
+    };
+    const nextOccurrence = calculateNextOccurrence(event);
+    expect(nextOccurrence).toEqual(new Date('2024-02-29T10:00:00Z'));
+  });
 });

--- a/client/src/lib/event-logic.ts
+++ b/client/src/lib/event-logic.ts
@@ -21,7 +21,14 @@ export const calculateNextOccurrence = (event: CalendarEvent): Date | null => {
       nextDate.setDate(nextDate.getDate() + 7);
       break;
     case 'monthly':
+      const originalDate = nextDate.getDate();
       nextDate.setMonth(nextDate.getMonth() + 1);
+      // If the new date's day is not the same, it means we've rolled over.
+      // For example, from Jan 31 to Feb 29 (or 28).
+      if (nextDate.getDate() !== originalDate) {
+        // This trick sets the date to the last day of the previous month.
+        nextDate.setDate(0);
+      }
       break;
     default:
       return null;


### PR DESCRIPTION
The `calculateNextOccurrence` function had a bug where it would incorrectly calculate the next occurrence of a monthly event if the event was on a day that did not exist in the next month (e.g., January 31st).

This was caused by the `setMonth` function rolling over the date to the next month.

The fix checks if the date has rolled over after incrementing the month. If it has, it sets the date to the last day of the correct month.

A new test case has been added to cover this scenario.